### PR TITLE
Fix timestamp parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ lamp <command> [flags]
 - `--regex <pattern>`: Regular expression pattern to filter logs
 - `--level <level>`: Filter logs by level (info, error, debug, etc.)
 - `--user <username>`: Filter logs by username
-- `--start <time>`: Filter logs after this time (format: 2006-01-02T15:04:05)
-- `--end <time>`: Filter logs before this time (format: 2006-01-02T15:04:05)
+- `--start <time>`: Filter logs after this time (format: 2006-01-02 15:04:05.000)
+- `--end <time>`: Filter logs before this time (format: 2006-01-02 15:04:05.000)
 - `--json`: Output in JSON format
 - `--csv <path>`: Export logs to CSV file at specified path
 - `--output <path>`: Save output to file instead of stdout

--- a/main.go
+++ b/main.go
@@ -192,8 +192,8 @@ func init() {
 		cmd.Flags().StringVar(&regexSearch, "regex", "", "Regular expression pattern to filter logs")
 		cmd.Flags().StringVar(&levelFilter, "level", "", "Filter logs by level (info, error, debug, etc.)")
 		cmd.Flags().StringVar(&userFilter, "user", "", "Filter logs by username")
-		cmd.Flags().StringVar(&startTime, "start", "", "Filter logs after this time (format: 2006-01-02T15:04:05)")
-		cmd.Flags().StringVar(&endTime, "end", "", "Filter logs before this time (format: 2006-01-02T15:04:05)")
+		cmd.Flags().StringVar(&startTime, "start", "", "Filter logs after this time (format: 2006-01-02 15:04:05.000)")
+		cmd.Flags().StringVar(&endTime, "end", "", "Filter logs before this time (format: 2006-01-02 15:04:05.000)")
 		cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 		cmd.Flags().StringVar(&csvOutput, "csv", "", "Export logs to CSV file at specified path")
 		cmd.Flags().StringVar(&outputFile, "output", "", "Save output to file instead of stdout")
@@ -237,7 +237,7 @@ func init() {
 		// Add time format hint completion
 		for _, flag := range []string{"start", "end"} {
 			registerFlagCompletion(cmd, flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-				return []string{"2006-01-02T15:04:05"}, cobra.ShellCompDirectiveNoFileComp
+				return []string{"2006-01-02 15:04:05.000"}, cobra.ShellCompDirectiveNoFileComp
 			})
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -45,14 +45,14 @@ func parseLogFile(filePath, searchTerm, regexPattern, levelFilter, userFilter, s
 	// Parse time range filters if provided
 	var startTime, endTime time.Time
 	if startTimeStr != "" {
-		parsedTime, parseErr := time.Parse("2006-01-02T15:04:05", startTimeStr)
+		parsedTime, parseErr := time.Parse("2006-01-02 15:04:05.000", startTimeStr)
 		if parseErr != nil {
 			return nil, fmt.Errorf("invalid start time format: %v", parseErr)
 		}
 		startTime = parsedTime
 	}
 	if endTimeStr != "" {
-		parsedTime, parseErr := time.Parse("2006-01-02T15:04:05", endTimeStr)
+		parsedTime, parseErr := time.Parse("2006-01-02 15:04:05.000", endTimeStr)
 		if parseErr != nil {
 			return nil, fmt.Errorf("invalid end time format: %v", parseErr)
 		}


### PR DESCRIPTION
The default format for log messages includes a space; see https://github.com/mattermost/logr/blob/bf3496ffac6944e40a669d06808b0dd6023e6097/formatter.go#L24-L25. The `--start` and `--end` flags should respect that.