### PR TITLE
include analyze compact and reduce analyze verbose size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # lamp 
 
-`lamp` (Log Analyser for Mattermost Packet) is a command-line tool for parsing, filtering, and displaying Mattermost log files with enhanced readability.
+`lamp` (Log Analyser for Mattermost Packet) is a command-line tool for parsing, filtering, and analyzing Mattermost log files with enhanced readability and intelligent insights.
 
 ## Features
 
+- **Smart analysis by default**: Automatically provides compact insights instead of overwhelming log dumps
 - Parse both traditional and JSON-formatted Mattermost log entries
-- Filter logs by search term, log level, and username
-- Display logs in a human-readable colored format or as JSON
-- Support for various Mattermost timestamp formats
+- Filter logs by search term, log level, username, and time ranges
+- **Intelligent log analysis** with statistics, patterns, and trends
+- **AI-powered analysis** using Claude, GPT, Gemini, or local models via Ollama
+- Display logs in human-readable colored format, JSON, or export to CSV
+- **Interactive terminal UI** for exploring large log files
+- Support for various Mattermost timestamp formats and support packets
 
 ## Installation
 
@@ -57,37 +61,51 @@ lamp <command> [flags]
 
 ### Commands
 
-- `file <path...>`: Parse one or more Mattermost log files
-- `support-packet <path>`: Parse a Mattermost support packet zip file
+- `file <path...>`: Parse and analyze one or more Mattermost log files
+- `notification <path>`: Parse and analyze a Mattermost notification log file  
+- `support-packet <path>`: Parse and analyze a Mattermost support packet zip file
 - `version`: Print version and build information
 - `completion`: Generate shell completion scripts
 - `help`: Help about any command
 
 ### Options
 
-- `--ai-analyze`: Analyze logs using AI
-- `--analyze`: Analyze logs and show statistics
+#### Analysis Options
+- `--ai-analyze`: Analyze logs using AI (Claude, GPT, Gemini, or Ollama)
+- `--analyze`: Show compact statistical analysis (same as default)
+- `--verbose-analysis`: Show detailed analysis with full sections
+- `--raw`: Output raw log entries instead of analysis
+
+#### AI Configuration  
 - `--api-key <key>`: API key for LLM provider
-- `--llm-provider <provider>`: LLM provider to use (anthropic, openai) (default: anthropic)
-- `--llm-model <model>`: LLM model to use (defaults to provider-specific default)
-- `--csv <path>`: Export logs to CSV file at specified path
-- `--end <time>`: Filter logs before this time (format: 2006-01-02 15:04:05.000)
-- `--help`: Show help information for any command
-- `--interactive`: Launch interactive TUI mode for exploring logs
-- `--json`: Output in JSON format
-- `--level <level>`: Filter logs by level (info, error, debug, etc.)
-- `--max-entries <num>`: Maximum number of log entries to send to Claude AI (default: 100)
-- `--output <path>`: Save output to file instead of stdout
-- `--problem "<description>"`: Description of the problem you're investigating (helps guide AI analysis)
-- `--quiet`: Only output errors (suppresses info, warn, and debug messages)
-- `--regex <pattern>`: Regular expression pattern to filter logs
-- `--search <term>`: Search term to filter logs
-- `--start <time>`: Filter logs after this time (format: 2006-01-02 15:04:05.000)
+- `--llm-provider <provider>`: LLM provider (anthropic, openai, gemini, ollama) (default: anthropic)
+- `--llm-model <model>`: LLM model to use (autocompletes based on provider)
+- `--max-entries <num>`: Maximum log entries to send to AI (default: 100)
+- `--problem "<description>"`: Problem description to guide AI analysis
 - `--thinking-budget <tokens>`: Token budget for Claude's extended thinking mode
-- `--trim`: Remove entries with duplicate information
-- `--trim-json <path>`: Write deduplicated logs to a JSON file at specified path
+- `--ollama-host <url>`: Ollama server URL (default: http://localhost:11434)
+- `--ollama-timeout <seconds>`: Ollama request timeout (default: 120)
+
+#### Filtering Options
+- `--search <term>`: Search term to filter logs
+- `--regex <pattern>`: Regular expression pattern to filter logs  
+- `--level <level>`: Filter by log level (info, error, debug, etc.) - supports autocomplete
 - `--user <username>`: Filter logs by username
+- `--start <time>`: Filter logs after this time (format: 2006-01-02 15:04:05.000)
+- `--end <time>`: Filter logs before this time (format: 2006-01-02 15:04:05.000)
+- `--trim`: Remove entries with duplicate information
+- `--trim-json <path>`: Write deduplicated logs to JSON file
+
+#### Output Options
+- `--json`: Output in JSON format
+- `--csv <path>`: Export logs to CSV file - supports file path autocomplete
+- `--output <path>`: Save output to file - supports file path autocomplete
+- `--interactive`: Launch interactive TUI mode for exploring logs
+
+#### Logging Options
 - `--verbose`: Enable debug level logging output
+- `--quiet`: Only output errors (suppresses info, warn, and debug messages)
+- `--help`: Show help information for any command
 
 ### Shell Completion
 
@@ -112,32 +130,46 @@ After enabling completion, you can use:
 
 ### Examples
 
-Parse a single log file:
+#### Basic Usage (New Default Behavior)
+
+Analyze a single log file (shows compact analysis by default):
 ```bash
 lamp file mattermost.log
 ```
 
-Parse multiple log files:
+Analyze multiple log files:
 ```bash
 lamp file mattermost.log mattermost2.log mattermost3.log
 ```
 
-Parse a support packet:
+Analyze a support packet:
 ```bash
 lamp support-packet mattermost_support_packet.zip
 ```
 
-Filter logs containing the word "error":
+Get detailed analysis with full sections:
+```bash
+lamp file mattermost.log --verbose-analysis
+```
+
+Get raw log output (old default behavior):
+```bash
+lamp file mattermost.log --raw
+```
+
+#### Filtering Examples
+
+Filter logs containing "error" (still shows analysis by default):
 ```bash
 lamp file mattermost.log --search "error"
 ```
 
-Show only error-level logs:
+Show analysis of only error-level logs:
 ```bash
 lamp file mattermost.log --level error
 ```
 
-Filter logs by user and output as JSON:
+Filter logs by user and export as JSON:
 ```bash
 lamp file mattermost.log --user admin --json
 ```
@@ -146,6 +178,13 @@ Combine multiple filters:
 ```bash
 lamp file mattermost.log --level error --search "database"
 ```
+
+Get raw filtered logs instead of analysis:
+```bash
+lamp file mattermost.log --level error --raw
+```
+
+#### Advanced Filtering
 
 Filter logs by time range:
 ```bash
@@ -157,14 +196,28 @@ Use regular expressions for advanced filtering:
 lamp file mattermost.log --regex "error.*database"
 ```
 
-Export logs to CSV for spreadsheet analysis:
+#### Export and Output Options
+
+Export analysis to CSV for spreadsheet analysis:
 ```bash
 lamp file mattermost.log --csv logs_export.csv
 ```
 
-Save output to a file:
+Save analysis to a file:
 ```bash
-lamp file mattermost.log --analyze --output analysis_report.txt
+lamp file mattermost.log --output analysis_report.txt
+```
+
+Export raw logs to CSV:
+```bash
+lamp file mattermost.log --raw --csv raw_logs.csv
+```
+
+#### Interactive and AI Analysis
+
+Launch interactive TUI mode for exploring logs:
+```bash
+lamp file mattermost.log --interactive
 ```
 
 Show version information:
@@ -172,12 +225,7 @@ Show version information:
 lamp version
 ```
 
-Launch interactive TUI mode for exploring logs:
-```bash
-lamp file mattermost.log --interactive
-```
-
-Analyze logs using AI:
+#### AI-Powered Analysis
 ```bash
 # Using Anthropic Claude (default provider)
 lamp file mattermost.log --ai-analyze --api-key YOUR_API_KEY
@@ -186,38 +234,56 @@ lamp file mattermost.log --ai-analyze --api-key YOUR_API_KEY
 export ANTHROPIC_API_KEY=YOUR_API_KEY
 lamp file mattermost.log --ai-analyze
 
-# Using OpenAI as the provider
+# Using OpenAI GPT models
 export OPENAI_API_KEY=YOUR_API_KEY
 lamp file mattermost.log --ai-analyze --llm-provider openai
 
-# Using a specific provider and model
-lamp file mattermost.log --ai-analyze --llm-provider anthropic --llm-model claude-3-sonnet-latest
+# Using Google Gemini models
+export GEMINI_API_KEY=YOUR_API_KEY
+lamp file mattermost.log --ai-analyze --llm-provider gemini
+
+# Using local Ollama models (no API key required)
+lamp file mattermost.log --ai-analyze --llm-provider ollama --llm-model llama3
+
+# Using a specific provider and model with autocomplete
+lamp file mattermost.log --ai-analyze --llm-provider anthropic --llm-model claude-opus-4-20250514
 
 # Specify maximum number of log entries to analyze
 lamp file mattermost.log --ai-analyze --max-entries 200
 
 # Provide a problem statement to guide the analysis
 lamp file mattermost.log --ai-analyze --problem "Users are reporting authentication failures"
+
+# Use extended thinking mode with Claude (more detailed analysis)
+lamp file mattermost.log --ai-analyze --thinking-budget 10000
 ```
 
-Analyze support packet logs using AI:
+Support packet AI analysis:
 ```bash
-# Using Anthropic Claude (default provider)
-lamp support-packet mattermost_support_packet.zip --ai-analyze --api-key YOUR_API_KEY
-
-# Using environment variable
+# Analyze entire support packet with AI
 export ANTHROPIC_API_KEY=YOUR_API_KEY
 lamp support-packet mattermost_support_packet.zip --ai-analyze
 
-# Using OpenAI
-lamp support-packet mattermost_support_packet.zip --ai-analyze --llm-provider openai --api-key YOUR_OPENAI_API_KEY
+# Use Ollama for local analysis
+lamp support-packet mattermost_support_packet.zip --ai-analyze --llm-provider ollama
 ```
 
-## Output Format
+## Output Formats
 
-### Pretty Print (Default)
+### Analysis (Default)
 
-The default output format includes:
+The default output provides a **compact analysis** instead of raw log dumps:
+- **Header**: Entry count, duration, and error rate
+- **Log levels**: Distribution with colored counts  
+- **Top sources**: Most active log sources
+- **Top errors**: Most frequent error messages (truncated for readability)
+- **Peak hours**: Busiest time periods
+
+Use `--verbose-analysis` for detailed analysis with full activity charts and patterns.
+
+### Raw Log Output
+
+When using the `--raw` flag, output includes:
 - Colored timestamps and log levels for better readability
 - Highlighted source/caller information
 - Structured display of user information and additional details
@@ -254,16 +320,21 @@ This is particularly useful for analyzing logs from multi-node Mattermost deploy
 
 ## Log Analysis
 
-The `--analyze` option provides a high-level overview of the log data, including:
+**Compact analysis** (now the default) provides a quick overview:
+- Basic statistics (total entries, time range, duration, error rate)
+- Log level distribution with colored counts
+- Top 3 log sources and error messages  
+- Top 3 peak activity hours
 
-- Basic statistics (total entries, time range, duration)
-- Log level distribution and error rate
-- Top log sources and active users
-- Most frequent error messages
-- Activity patterns by hour
-- Common message patterns
+**Detailed analysis** (`--verbose-analysis`) includes additional insights:
+- Full 24-hour activity charts with colored bars (skips zero-activity hours)
+- Day-of-week activity patterns (when spanning multiple days)
+- Monthly activity patterns (when spanning multiple months)
+- Only shows sections with relevant data
 
-This analysis helps quickly identify trends, issues, and patterns in large log files without having to manually review thousands of entries.
+**Explicit analysis** (`--analyze`) is the same as the default compact analysis.
+
+This smart analysis helps quickly identify trends, issues, and patterns in large log files without having to manually review thousands of entries or deal with overwhelming terminal output.
 
 ## Advanced Filtering
 
@@ -305,19 +376,24 @@ The `--ai-analyze` option uses AI to provide an intelligent analysis of your log
 - Offers recommendations for resolution
 - Gives context and insights that might not be obvious from statistical analysis
 
-Supported LLM providers:
-- Anthropic Claude (default) - requires an API key from [https://console.anthropic.com/](https://console.anthropic.com/)
-- OpenAI - requires an API key from [https://platform.openai.com/](https://platform.openai.com/)
+**Supported LLM providers:**
+- **Anthropic Claude** (default) - Get API key from [console.anthropic.com](https://console.anthropic.com/)
+- **OpenAI GPT** - Get API key from [platform.openai.com](https://platform.openai.com/)  
+- **Google Gemini** - Get API key from [console.cloud.google.com](https://console.cloud.google.com/)
+- **Ollama** - Local models, no API key required ([ollama.ai](https://ollama.ai/))
 
-You can provide the API key in two ways:
-1. Using the `--api-key` command line flag
-2. Setting the appropriate environment variable:
-   - For Anthropic: `ANTHROPIC_API_KEY`
-   - For OpenAI: `OPENAI_API_KEY`
+**API key configuration:**
+1. Command line flag: `--api-key YOUR_KEY`
+2. Environment variables:
+   - `ANTHROPIC_API_KEY` for Claude
+   - `OPENAI_API_KEY` for GPT models
+   - `GEMINI_API_KEY` for Gemini models
+   - No key needed for Ollama
 
-You can customize the LLM provider and model:
-- `--llm-provider`: Choose the LLM provider (anthropic, openai)
-- `--llm-model`: Specify a particular model (defaults to a provider-specific default)
+**Provider and model selection:**
+- `--llm-provider`: Choose provider (anthropic, openai, gemini, ollama)
+- `--llm-model`: Specify model with **tab autocomplete** based on selected provider
+- Models automatically complete based on your chosen provider
 
 Note: When using AI analysis, a limited number of log entries are sent to the LLM provider to stay within token limits. By default, the tool sends up to 100 entries, but you can adjust this with the `--max-entries` flag.
 
@@ -334,14 +410,17 @@ These flags are mutually exclusive - if both are provided, `--quiet` takes prece
 
 Examples:
 ```bash
-# Default behavior - show info and error messages
+# Default behavior - show compact analysis with info and error messages
 lamp file logfile.txt
 
-# Show detailed debug information
+# Show detailed debug information  
 lamp file logfile.txt --verbose
 
 # Only show errors
 lamp file logfile.txt --quiet
+
+# Get raw logs with detailed debug information
+lamp file logfile.txt --raw --verbose
 ```
 ## License
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -398,16 +398,16 @@ func displayAnalysis(analysis LogAnalysis, writer io.Writer, isDeduplicated bool
 			}
 			_, _ = fmt.Fprintln(writer, "")
 		} else {
-			// Compact errors - show top 2 with truncated messages
+			// Compact errors - show top 3 with truncated messages (consistent with verbose)
 			_, _ = fmt.Fprintf(writer, "%sTop Errors:%s ", subHeaderColor, resetColor)
 			for i, err := range analysis.TopErrorMessages {
-				if i >= 2 {
+				if i >= 3 {
 					break
 				}
 				if i > 0 {
 					_, _ = fmt.Fprintf(writer, " • ")
 				}
-				// Truncate error message further for compact view
+				// Truncate error message - use same length as verbose view
 				msg := err.Item
 				if len(msg) > 30 {
 					msg = msg[:30] + "..."

--- a/analyzer.go
+++ b/analyzer.go
@@ -41,7 +41,7 @@ type CountedItem struct {
 }
 
 // analyzeAndDisplayStats analyzes log entries and displays statistics
-func analyzeAndDisplayStats(logs []LogEntry, writer io.Writer, showDupes bool) {
+func analyzeAndDisplayStats(logs []LogEntry, writer io.Writer, showDupes bool, verboseAnalysis bool) {
 	if len(logs) == 0 {
 		_, _ = fmt.Fprintln(writer, "No log entries to analyze.")
 		return
@@ -68,7 +68,7 @@ func analyzeAndDisplayStats(logs []LogEntry, writer io.Writer, showDupes bool) {
 	isDeduplicated := hasDuplicateCounts && totalEntries > uniqueEntries && showDupes
 
 	analysis := analyzeLogs(logs, showDupes)
-	displayAnalysis(analysis, writer, isDeduplicated, uniqueEntries)
+	displayAnalysis(analysis, writer, isDeduplicated, uniqueEntries, verboseAnalysis)
 }
 
 // analyzeLogs performs analysis on log entries
@@ -286,146 +286,175 @@ func getDominantLevelColor(levelCounts map[string]int, totalCount int) string {
 }
 
 // displayAnalysis prints the analysis results
-func displayAnalysis(analysis LogAnalysis, writer io.Writer, isDeduplicated bool, uniqueEntries int) {
+func displayAnalysis(analysis LogAnalysis, writer io.Writer, isDeduplicated bool, uniqueEntries int, verboseAnalysis bool) {
 	// ANSI color codes
 	headerColor := "\033[1;36m"    // Bold Cyan
 	subHeaderColor := "\033[1;33m" // Bold Yellow
 	resetColor := "\033[0m"
 
-	_, _ = fmt.Fprintf(writer, "\n%s=== MATTERMOST LOG ANALYSIS ===%s\n\n", headerColor, resetColor)
-
-	// Basic statistics
-	_, _ = fmt.Fprintf(writer, "%sBasic Statistics:%s\n", subHeaderColor, resetColor)
-	if isDeduplicated {
-		_, _ = fmt.Fprintf(writer, "Unique Log Entries: %d\n", uniqueEntries)
-		_, _ = fmt.Fprintf(writer, "Total Log Entries: %d (including %d duplicates)\n",
-			analysis.TotalEntries, analysis.TotalEntries-uniqueEntries)
-		_, _ = fmt.Fprintf(writer, "Deduplication Ratio: %.2f:1\n", float64(analysis.TotalEntries)/float64(uniqueEntries))
+	if verboseAnalysis {
+		_, _ = fmt.Fprintf(writer, "\n%s=== MATTERMOST LOG ANALYSIS ===%s\n", headerColor, resetColor)
+		
+		// Compact basic statistics
+		duration := analysis.TimeRange.End.Sub(analysis.TimeRange.Start).Round(time.Second)
+		if isDeduplicated {
+			_, _ = fmt.Fprintf(writer, "%d entries (%d unique) • %s • Error rate: %.1f%%\n", 
+				analysis.TotalEntries, uniqueEntries, duration, analysis.ErrorRate)
+		} else {
+			_, _ = fmt.Fprintf(writer, "%d entries • %s • Error rate: %.1f%%\n", 
+				analysis.TotalEntries, duration, analysis.ErrorRate)
+		}
+		_, _ = fmt.Fprintf(writer, "%s to %s\n",
+			analysis.TimeRange.Start.Format("2006-01-02 15:04:05"),
+			analysis.TimeRange.End.Format("2006-01-02 15:04:05"))
 	} else {
-		_, _ = fmt.Fprintf(writer, "Total Log Entries: %d\n", analysis.TotalEntries)
+		// Compact header
+		_, _ = fmt.Fprintf(writer, "\n%sLOG ANALYSIS%s\n", headerColor, resetColor)
+		duration := analysis.TimeRange.End.Sub(analysis.TimeRange.Start).Round(time.Second)
+		if isDeduplicated {
+			_, _ = fmt.Fprintf(writer, "%d entries (%d unique) • %s • Error rate: %.1f%%\n\n", 
+				analysis.TotalEntries, uniqueEntries, duration, analysis.ErrorRate)
+		} else {
+			_, _ = fmt.Fprintf(writer, "%d entries • %s • Error rate: %.1f%%\n\n", 
+				analysis.TotalEntries, duration, analysis.ErrorRate)
+		}
 	}
-	_, _ = fmt.Fprintf(writer, "Time Range: %s to %s\n",
-		analysis.TimeRange.Start.Format("2006-01-02 15:04:05"),
-		analysis.TimeRange.End.Format("2006-01-02 15:04:05"))
-	_, _ = fmt.Fprintf(writer, "Duration: %s\n\n", analysis.TimeRange.End.Sub(analysis.TimeRange.Start).Round(time.Second))
 
 	// Log level distribution
-	_, _ = fmt.Fprintf(writer, "%sLog Level Distribution:%s\n", subHeaderColor, resetColor)
-	for level, count := range analysis.LevelCounts {
-		percentage := float64(count) / float64(analysis.TotalEntries) * 100
-		levelColor := getLevelColor(level)
-		_, _ = fmt.Fprintf(writer, "%s%s%s: %d (%.1f%%)\n", levelColor, level, resetColor, count, percentage)
+	if verboseAnalysis {
+		_, _ = fmt.Fprintf(writer, "%sLevels:%s ", subHeaderColor, resetColor)
+		first := true
+		for level, count := range analysis.LevelCounts {
+			if !first {
+				_, _ = fmt.Fprintf(writer, " • ")
+			}
+			percentage := float64(count) / float64(analysis.TotalEntries) * 100
+			levelColor := getLevelColor(level)
+			_, _ = fmt.Fprintf(writer, "%s%s%s:%d(%.0f%%)", levelColor, level, resetColor, count, percentage)
+			first = false
+		}
+		_, _ = fmt.Fprintln(writer, "")
+	} else {
+		// Compact level distribution - show on one line
+		_, _ = fmt.Fprintf(writer, "%sLevels:%s ", subHeaderColor, resetColor)
+		first := true
+		for level, count := range analysis.LevelCounts {
+			if !first {
+				_, _ = fmt.Fprintf(writer, " • ")
+			}
+			levelColor := getLevelColor(level)
+			_, _ = fmt.Fprintf(writer, "%s%s%s:%d", levelColor, level, resetColor, count)
+			first = false
+		}
+		_, _ = fmt.Fprintln(writer, "")
 	}
-	_, _ = fmt.Fprintf(writer, "Error Rate: %.2f%%\n\n", analysis.ErrorRate)
 
 	// Top sources
-	_, _ = fmt.Fprintf(writer, "%sTop Log Sources:%s\n", subHeaderColor, resetColor)
-	for i, source := range analysis.TopSources {
-		if i < 5 {
-			_, _ = fmt.Fprintf(writer, "%d. %s (%d entries)\n", i+1, source.Item, source.Count)
-		}
-	}
-	_, _ = fmt.Fprintln(writer)
-
-	// Top users (if any)
-	if len(analysis.TopUsers) > 0 {
-		_, _ = fmt.Fprintf(writer, "%sTop Active Users:%s\n", subHeaderColor, resetColor)
-		for i, user := range analysis.TopUsers {
-			if i < 5 {
-				_, _ = fmt.Fprintf(writer, "%d. %s (%d entries)\n", i+1, user.Item, user.Count)
+	if verboseAnalysis {
+		_, _ = fmt.Fprintf(writer, "%sSources:%s ", subHeaderColor, resetColor)
+		for i, source := range analysis.TopSources {
+			if i >= 3 {
+				break
 			}
+			if i > 0 {
+				_, _ = fmt.Fprintf(writer, " • ")
+			}
+			_, _ = fmt.Fprintf(writer, "%s(%d)", source.Item, source.Count)
 		}
-		_, _ = fmt.Fprintln(writer)
+		_, _ = fmt.Fprintln(writer, "")
+	} else if len(analysis.TopSources) > 0 {
+		// Compact sources - show top 3 on one line
+		_, _ = fmt.Fprintf(writer, "%sSources:%s ", subHeaderColor, resetColor)
+		for i, source := range analysis.TopSources {
+			if i >= 3 {
+				break
+			}
+			if i > 0 {
+				_, _ = fmt.Fprintf(writer, " • ")
+			}
+			_, _ = fmt.Fprintf(writer, "%s(%d)", source.Item, source.Count)
+		}
+		_, _ = fmt.Fprintln(writer, "")
 	}
+
 
 	// Top error messages (if any)
 	if len(analysis.TopErrorMessages) > 0 {
-		_, _ = fmt.Fprintf(writer, "%sTop Error Messages:%s\n", subHeaderColor, resetColor)
-		for i, err := range analysis.TopErrorMessages {
-			if i < 5 {
-				_, _ = fmt.Fprintf(writer, "%d. %s (%d occurrences)\n", i+1, err.Item, err.Count)
+		if verboseAnalysis {
+			_, _ = fmt.Fprintf(writer, "%sTop Errors:%s ", subHeaderColor, resetColor)
+			for i, err := range analysis.TopErrorMessages {
+				if i >= 3 {
+					break
+				}
+				if i > 0 {
+					_, _ = fmt.Fprintf(writer, " • ")
+				}
+				// Truncate error message for verbose view too
+				msg := err.Item
+				if len(msg) > 40 {
+					msg = msg[:40] + "..."
+				}
+				_, _ = fmt.Fprintf(writer, "%s(%d)", msg, err.Count)
+			}
+			_, _ = fmt.Fprintln(writer, "")
+		} else {
+			// Compact errors - show top 2 with truncated messages
+			_, _ = fmt.Fprintf(writer, "%sTop Errors:%s ", subHeaderColor, resetColor)
+			for i, err := range analysis.TopErrorMessages {
+				if i >= 2 {
+					break
+				}
+				if i > 0 {
+					_, _ = fmt.Fprintf(writer, " • ")
+				}
+				// Truncate error message further for compact view
+				msg := err.Item
+				if len(msg) > 30 {
+					msg = msg[:30] + "..."
+				}
+				_, _ = fmt.Fprintf(writer, "%s(%d)", msg, err.Count)
+			}
+			_, _ = fmt.Fprintln(writer, "")
+		}
+	}
+
+	// Peak hours - only in compact mode
+	if !verboseAnalysis {
+		// Compact hour activity - show only peak hours
+		_, _ = fmt.Fprintf(writer, "%sPeak Hours:%s ", subHeaderColor, resetColor)
+		
+		// Sort hours by activity and show top 3
+		sortedHours := make([]CountedItem, 0, len(analysis.BusiestHours))
+		for _, hour := range analysis.BusiestHours {
+			if hour.Count > 0 {
+				sortedHours = append(sortedHours, hour)
 			}
 		}
-		_, _ = fmt.Fprintln(writer)
-	}
-
-	// Busiest hours
-	_, _ = fmt.Fprintf(writer, "%sActivity by Hour:%s\n", subHeaderColor, resetColor)
-	// Find the max count for scaling
-	maxCount := 0
-	for _, hour := range analysis.BusiestHours {
-		if hour.Count > maxCount {
-			maxCount = hour.Count
-		}
-	}
-
-	// Create a map for easier hour lookup
-	hourMap := make(map[int]int)
-	for _, hour := range analysis.BusiestHours {
-		hourNum := 0
-		if _, err := fmt.Sscanf(hour.Item, "%d", &hourNum); err != nil {
-			logger.Debug("Invalid hour format in activity analysis", "hour", hour.Item, "error", err)
-			// Skip invalid hour entries
-			continue
-		}
-		if hourNum < 0 || hourNum >= 24 {
-			logger.Debug("Hour outside valid range", "hour", hourNum)
-			// Skip hours outside valid range
-			continue
-		}
-		hourMap[hourNum] = hour.Count
-	}
-
-	// Display hours with bar chart
-	for hour := 0; hour < 24; hour++ {
-		count := hourMap[hour]
-		barLength := int(float64(count) / float64(maxCount) * 30)
-		bar := strings.Repeat("█", barLength)
 		
-		// Get dominant log level color for this hour
-		levelColor := getDominantLevelColor(analysis.HourLevelCounts[hour], count)
+		// Sort by count (descending)
+		sort.Slice(sortedHours, func(i, j int) bool {
+			return sortedHours[i].Count > sortedHours[j].Count
+		})
 		
-		_, _ = fmt.Fprintf(writer, "%02d:00: %s%s%s (%d)\n", hour, levelColor, bar, resetColor, count)
+		for i, hour := range sortedHours {
+			if i >= 3 {
+				break
+			}
+			if i > 0 {
+				_, _ = fmt.Fprintf(writer, " • ")
+			}
+			_, _ = fmt.Fprintf(writer, "%sh(%d)", hour.Item, hour.Count)
+		}
+		_, _ = fmt.Fprintln(writer, "")
 	}
-	_, _ = fmt.Fprintln(writer)
 	
-	// Activity by day of week (if time range spans multiple days)
+	
+	// Activity by month (if time range spans multiple months) - verbose only
 	timeSpan := analysis.TimeRange.End.Sub(analysis.TimeRange.Start)
-	if timeSpan.Hours() >= 24 && len(analysis.ActivityByDayOfWeek) > 0 {
-		_, _ = fmt.Fprintf(writer, "%sActivity by Day of Week:%s\n", subHeaderColor, resetColor)
-		// Find the max count for scaling
-		maxCount = 0
-		for _, day := range analysis.ActivityByDayOfWeek {
-			if day.Count > maxCount {
-				maxCount = day.Count
-			}
-		}
-		
-		// Create a map for easier day lookup
-		dayMap := make(map[string]int)
-		for _, day := range analysis.ActivityByDayOfWeek {
-			dayMap[day.Item] = day.Count
-		}
-		
-		// Display days with bar chart (in order from Sunday to Saturday)
-		for _, day := range []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"} {
-			count := dayMap[day]
-			barLength := int(float64(count) / float64(maxCount) * 30)
-			bar := strings.Repeat("█", barLength)
-			
-			// Get dominant log level color for this day
-			levelColor := getDominantLevelColor(analysis.DayLevelCounts[day], count)
-			
-			_, _ = fmt.Fprintf(writer, "%-9s: %s%s%s (%d)\n", day, levelColor, bar, resetColor, count)
-		}
-		_, _ = fmt.Fprintln(writer)
-	}
-	
-	// Activity by month (if time range spans multiple months)
-	if timeSpan.Hours() >= 24*30 && len(analysis.ActivityByMonth) > 0 {
+	if verboseAnalysis && timeSpan.Hours() >= 24*30 && len(analysis.ActivityByMonth) > 0 {
 		_, _ = fmt.Fprintf(writer, "%sActivity by Month:%s\n", subHeaderColor, resetColor)
 		// Find the max count for scaling
-		maxCount = 0
+		maxCount := 0
 		for _, month := range analysis.ActivityByMonth {
 			if month.Count > maxCount {
 				maxCount = month.Count
@@ -452,17 +481,9 @@ func displayAnalysis(analysis LogAnalysis, writer io.Writer, isDeduplicated bool
 		_, _ = fmt.Fprintln(writer)
 	}
 
-	// Common message patterns
-	_, _ = fmt.Fprintf(writer, "%sCommon Message Patterns:%s\n", subHeaderColor, resetColor)
-	for i, pattern := range analysis.CommonPatterns {
-		if i < 5 {
-			_, _ = fmt.Fprintf(writer, "%d. \"%s\" (%d occurrences)\n", i+1, pattern.Item, pattern.Count)
-		}
-	}
-	_, _ = fmt.Fprintln(writer)
 	
-	// Notification statistics (if present)
-	if len(analysis.NotificationTypes) > 0 {
+	// Notification statistics (if present) - only in verbose mode
+	if verboseAnalysis && len(analysis.NotificationTypes) > 0 {
 		_, _ = fmt.Fprintf(writer, "%sNotification Statistics:%s\n", subHeaderColor, resetColor)
 		
 		// Notification types
@@ -483,7 +504,93 @@ func displayAnalysis(analysis LogAnalysis, writer io.Writer, isDeduplicated bool
 		_, _ = fmt.Fprintln(writer)
 	}
 
-	_, _ = fmt.Fprintf(writer, "\n%s=== END OF ANALYSIS ===%s\n\n", headerColor, resetColor)
+	// Activity sections at the bottom - verbose only
+	if verboseAnalysis {
+		// Activity by hour
+		_, _ = fmt.Fprintf(writer, "%sActivity by Hour:%s\n", subHeaderColor, resetColor)
+		// Find the max count for scaling
+		maxCount := 0
+		for _, hour := range analysis.BusiestHours {
+			if hour.Count > maxCount {
+				maxCount = hour.Count
+			}
+		}
+
+		// Create a map for easier hour lookup
+		hourMap := make(map[int]int)
+		for _, hour := range analysis.BusiestHours {
+			hourNum := 0
+			if _, err := fmt.Sscanf(hour.Item, "%d", &hourNum); err != nil {
+				logger.Debug("Invalid hour format in activity analysis", "hour", hour.Item, "error", err)
+				continue
+			}
+			if hourNum < 0 || hourNum >= 24 {
+				logger.Debug("Hour outside valid range", "hour", hourNum)
+				continue
+			}
+			hourMap[hourNum] = hour.Count
+		}
+
+		// Display hours with bar chart (skip zero activity hours)
+		for hour := 0; hour < 24; hour++ {
+			count := hourMap[hour]
+			if count == 0 {
+				continue // Skip hours with no activity
+			}
+			barLength := int(float64(count) / float64(maxCount) * 15) // Shorter bars
+			bar := strings.Repeat("█", barLength)
+			
+			// Get dominant log level color for this hour
+			levelColor := getDominantLevelColor(analysis.HourLevelCounts[hour], count)
+			
+			_, _ = fmt.Fprintf(writer, "%02d:00: %s%s%s (%d)\n", hour, levelColor, bar, resetColor, count)
+		}
+		_, _ = fmt.Fprintln(writer)
+
+		// Activity by day of week (if time range spans multiple days)
+		timeSpan := analysis.TimeRange.End.Sub(analysis.TimeRange.Start)
+		if timeSpan.Hours() >= 24 && len(analysis.ActivityByDayOfWeek) > 0 {
+			_, _ = fmt.Fprintf(writer, "%sActivity by Day of Week:%s\n", subHeaderColor, resetColor)
+			// Find the max count for scaling
+			maxCount := 0
+			for _, day := range analysis.ActivityByDayOfWeek {
+				if day.Count > maxCount {
+					maxCount = day.Count
+				}
+			}
+			
+			// Create a map for easier day lookup
+			dayMap := make(map[string]int)
+			for _, day := range analysis.ActivityByDayOfWeek {
+				dayMap[day.Item] = day.Count
+			}
+			
+			// Display days with bar chart (in order from Sunday to Saturday, skip zero days)
+			dayNames := []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}
+			dayAbbrevs := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+			for i, day := range dayNames {
+				count := dayMap[day]
+				if count == 0 {
+					continue // Skip days with no activity
+				}
+				barLength := int(float64(count) / float64(maxCount) * 15) // Shorter bars
+				bar := strings.Repeat("█", barLength)
+				
+				// Get dominant log level color for this day
+				levelColor := getDominantLevelColor(analysis.DayLevelCounts[day], count)
+				
+				_, _ = fmt.Fprintf(writer, "%s: %s%s%s (%d)\n", dayAbbrevs[i], levelColor, bar, resetColor, count)
+			}
+			_, _ = fmt.Fprintln(writer)
+		}
+	}
+
+	// Footer
+	if verboseAnalysis {
+		_, _ = fmt.Fprintf(writer, "\n%s=== END OF ANALYSIS ===%s\n\n", headerColor, resetColor)
+	} else {
+		_, _ = fmt.Fprintln(writer, "")
+	}
 }
 
 // getLevelColor returns the ANSI color code for a log level

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -292,13 +292,12 @@ func TestDisplayAnalysis(t *testing.T) {
 
 	t.Run("display analysis output formatting", func(t *testing.T) {
 		var buf bytes.Buffer
-		displayAnalysis(analysis, &buf, false, 10)
+		displayAnalysis(analysis, &buf, false, 10, true)
 		output := buf.String()
 		
 		// Check that all expected sections are present
 		assert.Contains(t, output, "=== MATTERMOST LOG ANALYSIS ===")
-		assert.Contains(t, output, "Basic Statistics:")
-		assert.Contains(t, output, "Log Level Distribution:")
+		assert.Contains(t, output, "Levels:")
 		assert.Contains(t, output, "Activity by Hour:")
 		assert.Contains(t, output, "Activity by Day of Week:")
 		assert.Contains(t, output, "Activity by Month:")
@@ -312,18 +311,17 @@ func TestDisplayAnalysis(t *testing.T) {
 		assert.Contains(t, output, "ERROR")
 		
 		// Check error rate
-		assert.Contains(t, output, "Error Rate: 20.00%")
+		assert.Contains(t, output, "Error rate: 20.0%")
 	})
 
 	t.Run("display analysis with deduplication info", func(t *testing.T) {
 		var buf bytes.Buffer
-		displayAnalysis(analysis, &buf, true, 8) // 8 unique entries out of 10 total
+		displayAnalysis(analysis, &buf, true, 8, true) // 8 unique entries out of 10 total
 		output := buf.String()
 		
-		// Check deduplication info
-		assert.Contains(t, output, "Unique Log Entries: 8")
-		assert.Contains(t, output, "Total Log Entries: 10")
-		assert.Contains(t, output, "Deduplication Ratio")
+		// Check deduplication info (verbose analysis shows entries count and duration)
+		assert.Contains(t, output, "10 entries (8 unique)")
+		assert.Contains(t, output, "1421h45m0s")
 	})
 
 	t.Run("display time range condition for day and month charts", func(t *testing.T) {
@@ -335,7 +333,7 @@ func TestDisplayAnalysis(t *testing.T) {
 		}
 		
 		var buf bytes.Buffer
-		displayAnalysis(shortAnalysis, &buf, false, 10)
+		displayAnalysis(shortAnalysis, &buf, false, 10, true)
 		output := buf.String()
 		
 		// Day of week chart should NOT be present for short time ranges
@@ -370,16 +368,16 @@ func TestAnalyzeAndDisplayStats(t *testing.T) {
 
 	t.Run("display stats without duplicates", func(t *testing.T) {
 		var buf bytes.Buffer
-		analyzeAndDisplayStats(logs, &buf, false)
+		analyzeAndDisplayStats(logs, &buf, false, false)
 		output := buf.String()
 		
-		assert.Contains(t, output, "Total Log Entries: 3")
+		assert.Contains(t, output, "3 entries")
 		assert.NotContains(t, output, "Deduplication Ratio")
 	})
 
 	t.Run("handle empty logs", func(t *testing.T) {
 		var buf bytes.Buffer
-		analyzeAndDisplayStats([]LogEntry{}, &buf, false)
+		analyzeAndDisplayStats([]LogEntry{}, &buf, false, false)
 		output := buf.String()
 		
 		assert.Contains(t, output, "No log entries to analyze.")
@@ -405,11 +403,9 @@ func TestAnalyzeAndDisplayStats(t *testing.T) {
 		}
 		
 		var buf bytes.Buffer
-		analyzeAndDisplayStats(duplicateLogs, &buf, true)
+		analyzeAndDisplayStats(duplicateLogs, &buf, true, false)
 		output := buf.String()
 		
-		assert.Contains(t, output, "Unique Log Entries: 2")
-		assert.Contains(t, output, "Total Log Entries: 5")
-		assert.Contains(t, output, "Deduplication Ratio")
+		assert.Contains(t, output, "5 entries (2 unique)")
 	})
 }

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	verbose        bool
 	quiet          bool
 	verboseAnalysis bool
+	rawOutput      bool
 
 	// Global logger
 	logger *slog.Logger
@@ -59,7 +60,7 @@ and AI-powered insights using LLM technology.`,
 
 var fileCmd = &cobra.Command{
 	Use:   "file [path...]",
-	Short: "Parse one or more Mattermost log files",
+	Short: "Parse and analyze one or more Mattermost log files",
 	Args:  cobra.MinimumNArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveFilterFileExt | cobra.ShellCompDirectiveDefault
@@ -134,7 +135,7 @@ var fileCmd = &cobra.Command{
 
 var notificationCmd = &cobra.Command{
 	Use:   "notification [path]",
-	Short: "Parse a Mattermost notification log file",
+	Short: "Parse and analyze a Mattermost notification log file",
 	Args:  cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
@@ -159,7 +160,7 @@ var notificationCmd = &cobra.Command{
 
 var supportPacketCmd = &cobra.Command{
 	Use:   "support-packet [path]",
-	Short: "Parse a Mattermost support packet zip file",
+	Short: "Parse and analyze a Mattermost support packet zip file",
 	Args:  cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
@@ -297,6 +298,7 @@ func init() {
 		cmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose output logging")
 		cmd.Flags().BoolVar(&quiet, "quiet", false, "Only output errors")
 		cmd.Flags().BoolVar(&verboseAnalysis, "verbose-analysis", false, "Show detailed analysis with all sections")
+		cmd.Flags().BoolVar(&rawOutput, "raw", false, "Output raw log entries instead of analysis (old default behavior)")
 
 		// Add custom completion for flags
 		registerFlagCompletion(cmd, "level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -340,7 +342,7 @@ func init() {
 		})
 
 		// Add boolean flag completion
-		for _, flag := range []string{"json", "analyze", "ai-analyze", "trim", "interactive", "verbose", "quiet", "verbose-analysis"} {
+		for _, flag := range []string{"json", "analyze", "ai-analyze", "trim", "interactive", "verbose", "quiet", "verbose-analysis", "raw"} {
 			registerFlagCompletion(cmd, flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 				return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 			})
@@ -506,8 +508,11 @@ func processLogs(logs []LogEntry) error {
 		analyzeAndDisplayStats(logs, output, !trim, verboseAnalysis)
 	case jsonOutput:
 		displayLogsJSON(logs, output)
-	default:
+	case rawOutput:
 		displayLogsPretty(logs, output)
+	default:
+		// Default to compact analysis instead of dumping all logs
+		analyzeAndDisplayStats(logs, output, !trim, verboseAnalysis)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	interactive    bool
 	verbose        bool
 	quiet          bool
+	verboseAnalysis bool
 
 	// Global logger
 	logger *slog.Logger
@@ -295,6 +296,7 @@ func init() {
 		cmd.Flags().BoolVar(&interactive, "interactive", false, "Launch interactive TUI mode")
 		cmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose output logging")
 		cmd.Flags().BoolVar(&quiet, "quiet", false, "Only output errors")
+		cmd.Flags().BoolVar(&verboseAnalysis, "verbose-analysis", false, "Show detailed analysis with all sections")
 
 		// Add custom completion for flags
 		registerFlagCompletion(cmd, "level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -338,7 +340,7 @@ func init() {
 		})
 
 		// Add boolean flag completion
-		for _, flag := range []string{"json", "analyze", "ai-analyze", "trim", "interactive", "verbose", "quiet"} {
+		for _, flag := range []string{"json", "analyze", "ai-analyze", "trim", "interactive", "verbose", "quiet", "verbose-analysis"} {
 			registerFlagCompletion(cmd, flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 				return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 			})
@@ -501,7 +503,7 @@ func processLogs(logs []LogEntry) error {
 			return fmt.Errorf("error during LLM analysis: %v", err)
 		}
 	case analyze:
-		analyzeAndDisplayStats(logs, output, !trim)
+		analyzeAndDisplayStats(logs, output, !trim, verboseAnalysis)
 	case jsonOutput:
 		displayLogsJSON(logs, output)
 	default:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/031abf54-30df-45d1-a783-89e7c5e82425)

![image](https://github.com/user-attachments/assets/3a9fbff0-ab2f-4ca8-bc6b-fdce97f774d5)

analyze now defaults to a compact view, old view can be shown with `--verbose-analyze` but has also been reduced in size